### PR TITLE
Uncomment line for installing sfml header files in switch install script

### DIFF
--- a/switch-install.sh
+++ b/switch-install.sh
@@ -8,4 +8,4 @@ cd ..
 
 sudo cp bin/switch/libWizEngine.a $DEVKITPRO/portlibs/switch/lib/
 sudo cp -r include/* $DEVKITPRO/portlibs/switch/include/
-#sudo cp -r build-switch/_deps/sfml-src/include/* $DEVKITPRO/portlibs/switch/include/
+sudo cp -r build-switch/_deps/sfml-src/include/* $DEVKITPRO/portlibs/switch/include/


### PR DESCRIPTION
This is required for me in order to import the headers for SFML in WizEngineQuickStart.